### PR TITLE
fix no peko button at first load caused by init lang

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -117,9 +117,12 @@ export default {
       let lang = navigator.language;
       if (lang === "zh" || lang === "zh-CN") {
         this.$i18n.locale = "zhHans";
+        localStorage.setItem("lang", "zhHans");
       } else if (lang === "ja" || lang === "ja-JP") {
         this.$i18n.locale = "ja";
+        localStorage.setItem("lang", "ja");
       } else {
+        this.$i18n.locale = "en";
         localStorage.setItem("lang", "en");
       }
     }


### PR DESCRIPTION
This is happening due to locale value is not en. Meaning you need to reload the page to get the proper value from the cookie and the rendering of buttons can be done correctly.

![image](https://user-images.githubusercontent.com/47969743/87173771-70e9ac80-c300-11ea-9f45-8e2ce360db29.png)

Next, I've put the other language into the cookie because the logic prioritizes the cookie instead of taking the value from `navigator.language`. so, in the next load, this will take the language value from the cookie as the priority.